### PR TITLE
Fix issue on startup beginning with v1.1.10f1

### DIFF
--- a/ZoningToolkitModToolSystem.cs
+++ b/ZoningToolkitModToolSystem.cs
@@ -424,7 +424,6 @@ namespace ZoningToolkit
             this.onUpdateMemory = default;
             this.workingState.lastRaycastEntity = Entity.Null;
             this.workingState.lastRaycastEntities = new NativeHashSet<Entity>(32, Allocator.Persistent);
-            this.applyActionNameOverride.state = DisplayNameOverride.State.GlobalHint;
             this.toolStateMachine.reset();
         }
 
@@ -434,7 +433,6 @@ namespace ZoningToolkit
             base.OnStopRunning();
             this.applyAction.shouldBeEnabled = false;
             this.toolEnabled = false;
-            this.applyActionNameOverride.state = DisplayNameOverride.State.Off;
             this.workingState.lastRaycastEntities.Dispose();
             this.onUpdateMemory.currentInputDeps.Complete();
         }


### PR DESCRIPTION
The DisplayNameOverride dependency changed in that it no longer has a state field or static States. This was breaking the code and causing the mod to fail its load during startup.

This PR removes two lines of code that were updating the display name override's state in the OnStartRunning / OnStopRunning lifecycle methods. I'm not sure if an equivalent piece of state needs to be updated elsewhere, but doing this at least got the mod running again for me